### PR TITLE
Git config for canonical repo when pushing

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ Usage: ss-tool [OPTION]...
 
 
   EXAMPLE(s):
-      ss-tool --cleanup -g 243 -t $GITHUB_TOKEN -u "Andrew Turpin" -e "fake.email@replace.me.com"
+      ss-tool --cleanup -g 243 -t $GITHUB_TOKEN -u "user name" -e "fake.email@replace.me.com"
            will use the github personal access token to clone the repositories
            then it will remove all git cloned repositories & docker db when done
            and will add a git-ref of '243-ss_tool-db-auto-update' when pushing the changes
-           showing the user who pushed the change as Andrew Turpin linked to email address fake.email@replace.me.com
+           showing the user who pushed the change as 'user name' linked to email address fake.email@replace.me.com
 
       ss-tool.conf:
           [canonical-database] section

--- a/README.md
+++ b/README.md
@@ -16,15 +16,18 @@ Usage: ss-tool [OPTION]...
     -g, --git-ref   add an optional custom git reference eg 243 to match issue 243
     -p, --push-git  push to GitHub, default behaviour creates branch but does not push
     -t, --token     the authorization token to use when pulling from a git repo
+    -e, --email     the email to use for GitHub configuration when pushing
+    -u, --username  the user name to use for GitHub configuration when pushing
         --help      display this help and exit
         --version   display version and exit
 
 
   EXAMPLE(s):
-      ss-tool --cleanup -g 243 -t $GITHUB_TOKEN
+      ss-tool --cleanup -g 243 -t $GITHUB_TOKEN -u "Andrew Turpin"
            will use the github personal access token to clone the repositories
            then it will remove all git cloned repositories & docker db when done
-           and add a git-ref of '243-ss_tool-db-auto-update' when pushing the changes
+           and will add a git-ref of '243-ss_tool-db-auto-update' when pushing the changes
+           showing the user who pushed the change as Andrew Turpin
 
       ss-tool.conf:
           [canonical-database] section

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ Usage: ss-tool [OPTION]...
 
 
   EXAMPLE(s):
-      ss-tool --cleanup -g 243 -t $GITHUB_TOKEN -u "Andrew Turpin"
+      ss-tool --cleanup -g 243 -t $GITHUB_TOKEN -u "Andrew Turpin" -e "fake.email@replace.me.com"
            will use the github personal access token to clone the repositories
            then it will remove all git cloned repositories & docker db when done
            and will add a git-ref of '243-ss_tool-db-auto-update' when pushing the changes
-           showing the user who pushed the change as Andrew Turpin
+           showing the user who pushed the change as Andrew Turpin linked to email address fake.email@replace.me.com
 
       ss-tool.conf:
           [canonical-database] section

--- a/ss-tool.sh
+++ b/ss-tool.sh
@@ -41,10 +41,10 @@ function displayHelp(){
     echo "";
     echo "";
     echo "  EXAMPLE(s):";
-    echo "      ss-tool --cleanup -g 243 -u 'Andrew Turpin'";
+    echo "      ss-tool --cleanup -g 243 -u 'Andrew Turpin' -e 'fake.email@replace.me.com'";
     echo "           will remove all git cloned repositories & docker db when done";
     echo "           and add a git-ref of '243-ss_tool-db-auto-update' when pushing the changes";
-    echo "           also, the branch will show as being pushed by Andrew Turpin on GitHub";
+    echo "           also, the branch will show as being pushed by Andrew Turpin (fake.email@replace.me.com) on GitHub";
     echo "";
     echo "      ss-tool.conf:";
     echo "          [canonical-database] section";

--- a/ss-tool.sh
+++ b/ss-tool.sh
@@ -20,8 +20,6 @@ _token=""
 _gitUsername="Andrew Turpin"
 _gitEmail=""
 _canonical_flyway="migrations"
-_full_canonical_path = ""
-
 
 function displayHelp(){
     echo "Usage: ss-tool [OPTION]...";
@@ -194,8 +192,7 @@ function processConfig(){
              
              if [ "$header" == "canonical" ]; then 
                _canonical_sql="$flywaySchemaConf";
-               $flywaySchemaConf = "public";
-               $_canonical_flyway="$flywayLocationConf";
+               _canonical_flyway="$flywayLocationConf";
              fi
              
              if [ "$header" == "microservice" ]; then
@@ -287,12 +284,13 @@ if [ -n "$_configFile" ]; then
 	done
     IFS="${OLDIFS}"
     
+    _full_canonical_path="$_here/flyway_data/$_canonical_folder"
     if [ -n "$_canonical_flyway" ]; then
       evaluate "mkdir -p $_here/flyway_data/$_canonical_folder/$_canonical_flyway"
-      $_full_canonical_path = "$_here/flyway_data/$_canonical_folder/$_canonical_flyway/$_canonical_sql";
+      _full_canonical_path="$_full_canonical_path/$_canonical_flyway/$_canonical_sql";
     else
       evaluate "mkdir -p $_here/flyway_data/$_canonical_folder"
-      $_full_canonical_path = "$_here/flyway_data/$_canonical_folder/$_canonical_sql";
+      _full_canonical_path="$_full_canonical_path/$_canonical_sql";
     fi
     
     evaluate "docker exec -u postgres ss-tool_postgresql_1 pg_dump -d canonical --schema-only  > $_full_canonical_path"
@@ -322,7 +320,7 @@ if [ -n "$_configFile" ]; then
         
     if [ "$_cleanup" == "1" ]; then cleanUp; fi; 
     msg ""
-    msg "Done! SQL for Canonical DB is at: '$_full_canonical_pah'"
+    msg "Done! SQL for Canonical DB is at: '$_full_canonical_path'"
     exit 0; 
 fi;
 

--- a/ss-tool.sh
+++ b/ss-tool.sh
@@ -41,10 +41,10 @@ function displayHelp(){
     echo "";
     echo "";
     echo "  EXAMPLE(s):";
-    echo "      ss-tool --cleanup -g 243 -u 'Andrew Turpin' -e 'fake.email@replace.me.com'";
+    echo "      ss-tool --cleanup -g 243 -u 'user name' -e 'fake.email@replace.me.com'";
     echo "           will remove all git cloned repositories & docker db when done";
     echo "           and add a git-ref of '243-ss_tool-db-auto-update' when pushing the changes";
-    echo "           also, the branch will show as being pushed by Andrew Turpin (fake.email@replace.me.com) on GitHub";
+    echo "           also, the branch will show as being pushed by 'user name' (fake.email@replace.me.com) on GitHub";
     echo "";
     echo "      ss-tool.conf:";
     echo "          [canonical-database] section";

--- a/ss-tool.sh
+++ b/ss-tool.sh
@@ -5,7 +5,7 @@
 #-----------------------------------------------------------------------
 
 # Globals
-_version="0.6"
+_version="0.7"
 _silent="0"
 _configFile="ss-tool.conf"
 _cleanup="0"
@@ -17,6 +17,10 @@ _push_git="0"
 _fw_path=""
 _fw_schema=""
 _token=""
+_gitUsername="Andrew Turpin"
+_gitEmail=""
+_canonical_flyway="migrations"
+_full_canonical_path = ""
 
 
 function displayHelp(){
@@ -32,14 +36,17 @@ function displayHelp(){
     echo "    -g, --git-ref   add an optional custom git reference eg 243 to match issue 243";
     echo "    -p, --push-git  push to GitHub, default behaviour creates branch but does not push";
     echo "    -t, --token     the authorization token to use when pulling from a git repo";
+    echo "    -e, --email     the email to use for GitHub configuration when pushing";
+    echo "    -u, --username  the user name to use for GitHub configuration when pushing";
     echo "        --help      display this help and exit";
     echo "        --version   display version and exit";
     echo "";
     echo "";
     echo "  EXAMPLE(s):";
-    echo "      ss-tool --cleanup -g 243";
+    echo "      ss-tool --cleanup -g 243 -u 'Andrew Turpin'";
     echo "           will remove all git cloned repositories & docker db when done";
     echo "           and add a git-ref of '243-ss_tool-db-auto-update' when pushing the changes";
+    echo "           also, the branch will show as being pushed by Andrew Turpin on GitHub";
     echo "";
     echo "      ss-tool.conf:";
     echo "          [canonical-database] section";
@@ -188,6 +195,7 @@ function processConfig(){
              if [ "$header" == "canonical" ]; then 
                _canonical_sql="$flywaySchemaConf";
                $flywaySchemaConf = "public";
+               $_canonical_flyway="$flywayLocationConf";
              fi
              
              if [ "$header" == "microservice" ]; then
@@ -235,6 +243,12 @@ while [[ "$#" > 0 ]]; do
         -t|--token) 
             _token="$2";
             shift;; 
+        -e|--email) 
+            _gitEmail="$2";
+            shift;; 
+        -u|--username) 
+            _gitUsername="$2";
+            shift;; 
          *) echo "Unknown parameter passed: $1"; exit 1;;
     esac; 
     shift; 
@@ -273,16 +287,33 @@ if [ -n "$_configFile" ]; then
 	done
     IFS="${OLDIFS}"
     
-    evaluate "mkdir -p $_here/flyway_data/$_canonical_folder/"
-    evaluate "docker exec -u postgres ss-tool_postgresql_1 pg_dump -d canonical --schema-only  > $_here/flyway_data/$_canonical_folder/$_canonical_sql"
+    if [ -n "$_canonical_flyway" ]; then
+      evaluate "mkdir -p $_here/flyway_data/$_canonical_folder/$_canonical_flyway"
+      $_full_canonical_path = "$_here/flyway_data/$_canonical_folder/$_canonical_flyway/$_canonical_sql";
+    else
+      evaluate "mkdir -p $_here/flyway_data/$_canonical_folder"
+      $_full_canonical_path = "$_here/flyway_data/$_canonical_folder/$_canonical_sql";
+    fi
+    
+    evaluate "docker exec -u postgres ss-tool_postgresql_1 pg_dump -d canonical --schema-only  > $_full_canonical_path"
     
     if [ $_push_git == "1" ]; then 
       if [ -z "$_token" ]; then
         msg "Pushing is only allowed with private repos"
       else
         evaluate "cd $_here/flyway_data/$_canonical_folder"
-        evaluate "git checkout -b $_git_ref-ss_tool-db-auto-update" 
-        evaluate "git add $_canonical_sql"
+        if [ -n "$_gitEmail" ]; then
+          evaluate "git config --local user.email $_gitEmail"
+        fi
+        if [ -n "$_gitUsername" ]; then
+          evaluate "git config --local user.name $_gitUsername"
+        fi
+        evaluate "git checkout -b $_git_ref-ss_tool-db-auto-update"
+        if [ -n "$_canonical_flyway" ]; then
+          evaluate "git add $_canonical_flyway/$_canonical_sql"
+        else
+          evaluate "git add $_canonical_sql"
+        fi
         evaluate "git commit -m $_git_ref-ss_tool-db-auto-update"
         evaluate "git push --set-upstream origin $_git_ref-ss_tool-db-auto-update"
       fi
@@ -291,7 +322,7 @@ if [ -n "$_configFile" ]; then
         
     if [ "$_cleanup" == "1" ]; then cleanUp; fi; 
     msg ""
-    msg "Done! SQL for Canonical DB is at: '$_here/flyway_data/$_canonical_folder/$_canonical_sql'"
+    msg "Done! SQL for Canonical DB is at: '$_full_canonical_pah'"
     exit 0; 
 fi;
 


### PR DESCRIPTION
Update to address:
1) A git fatal error if the `user.name` and `user.email` are not configured for a git repository when pushing. 
2) Support for a "migrations" folder inside the canonical repo to use when creating the merged script